### PR TITLE
fix compare with branches with a "/" in them

### DIFF
--- a/web/src/lib/diff-viewer-multi-file.svelte.ts
+++ b/web/src/lib/diff-viewer-multi-file.svelte.ts
@@ -418,11 +418,11 @@ export class MultiFileDiffViewerState {
 
         try {
             if (type === "commit") {
-                const { info, files } = await fetchGithubCommitDiff(token, owner, repo, id);
+                const { info, files } = await fetchGithubCommitDiff(token, owner, repo, id.split("/")[0]);
                 this.loadPatches(files, { githubDetails: info });
                 return true;
             } else if (type === "pull") {
-                const { info, files } = await fetchGithubPRComparison(token, owner, repo, id);
+                const { info, files } = await fetchGithubPRComparison(token, owner, repo, id.split("/")[0]);
                 this.loadPatches(files, { githubDetails: info });
                 return true;
             } else if (type === "compare") {

--- a/web/src/routes/diff/+page.svelte
+++ b/web/src/routes/diff/+page.svelte
@@ -93,10 +93,13 @@
 
     async function handleGithubUrl() {
         modalOpen = false;
-
-        const regex = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(commit|pull|compare)\/([^/]+)/;
-        const match = githubUrl.match(regex);
-
+        const url = new URL(githubUrl);
+        // exclude hash + query params
+        const test = url.protocol + url.hostname + url.pathname
+        
+        const regex = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(commit|pull|compare)\/(.+)/;
+        const match = test.match(regex);
+        
         if (!match) {
             alert("Invalid GitHub URL. Use: https://github.com/owner/repo/(commit|pull|compare)/(id|ref_a...ref_b)");
             modalOpen = true;

--- a/web/src/routes/diff/+page.svelte
+++ b/web/src/routes/diff/+page.svelte
@@ -95,11 +95,11 @@
         modalOpen = false;
         const url = new URL(githubUrl);
         // exclude hash + query params
-        const test = url.protocol + url.hostname + url.pathname
-        
+        const test = url.protocol + url.hostname + url.pathname;
+
         const regex = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(commit|pull|compare)\/(.+)/;
         const match = test.match(regex);
-        
+
         if (!match) {
             alert("Invalid GitHub URL. Use: https://github.com/owner/repo/(commit|pull|compare)/(id|ref_a...ref_b)");
             modalOpen = true;


### PR DESCRIPTION
Compare only url protocol, hostname, and pathname. relax pathname id slash requirements, stripping them later