### PR TITLE
Add slashes to url

### DIFF
--- a/web/src/routes/diff/+page.svelte
+++ b/web/src/routes/diff/+page.svelte
@@ -95,7 +95,7 @@
         modalOpen = false;
         const url = new URL(githubUrl);
         // exclude hash + query params
-        const test = url.protocol + url.hostname + url.pathname;
+        const test = url.protocol + "//" + url.hostname + url.pathname;
 
         const regex = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(commit|pull|compare)\/(.+)/;
         const match = test.match(regex);


### PR DESCRIPTION
add 2 slashes when parsing url. https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol doesn't mention the slashes being included either