### PR TITLE
Use replaceState when leaving redirect pages

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -45,7 +45,7 @@
         token.value = localStorage.getItem("token");
 
         if (token.value === null) {
-            await goto("/login");
+            await goto("/login", { replaceState: true });
             return;
         }
 
@@ -118,7 +118,7 @@
                     onclick={() => {
                         localStorage.removeItem("token");
                         token.value = null;
-                        goto("/login");
+                        goto("/login", { replaceState: true });
                     }}
                 >
                     Logout

--- a/web/src/routes/github-callback/+page.svelte
+++ b/web/src/routes/github-callback/+page.svelte
@@ -17,9 +17,9 @@
         const authReferrer = localStorage.getItem("authReferrer");
         if (authReferrer) {
             localStorage.removeItem("authReferrer");
-            await goto(authReferrer);
+            await goto(authReferrer, { replaceState: true });
         } else {
-            await goto("/");
+            await goto("/", { replaceState: true });
         }
     }
 

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -11,7 +11,7 @@
     });
 
     function onLogin() {
-        goto("/");
+        goto("/", { replaceState: true });
     }
 </script>
 


### PR DESCRIPTION
Its not nice when redirects prevent you from using the back button, instead, lets prefer to replace state when the user cannot return via the back button.